### PR TITLE
ci: run gitleaks in lint pipeline

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          # History is required by gitleaks
+          fetch-depth: 0
 
       - uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
The lint pipeline now runs [gitleaks](https://gitleaks.io/). This tool requires the broader commit history to be available, hence I'm switching the checkout action's fetch depth from `1` (implicit default) to `0`.