### PR TITLE
ci: Disable Renovate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,35 +1,18 @@
 {
-  "extends": [
-    "config:recommended"
-  ],
-  "enabledManagers": [
-    "gomod"
-  ],
-  "dependencyDashboard": true,
-  "ignorePaths": [
-    "vendor/**"
-  ],
-  "labels": [
-    "renovate"
-  ],
+  "extends": ["config:recommended"],
+  "enabledManagers": ["gomod"],
+  "dependencyDashboard": false,
+  "ignorePaths": ["vendor/**"],
+  "labels": ["renovate"],
   "packageRules": [
     {
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchUpdateTypes": [
-        "patch",
-        "minor"
-      ],
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["patch", "minor"],
       "automerge": false
     },
     {
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ],
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["major"],
       "groupName": "major Go module updates",
       "automerge": false
     }


### PR DESCRIPTION
Don't need it at the moment and doesn't bring much value.