### PR TITLE
feat: Format Fibonacci sequence items as JSON strings to avoid data corruption

### DIFF
--- a/controller/fibonacci.go
+++ b/controller/fibonacci.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"bytes"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -19,7 +20,7 @@ type GetFibonacciPathParams struct {
 //	@Tags			fibonacci
 //	@Param			count	path	GetFibonacciPathParams	true	"Desired sequence size"
 //	@Produce		json
-//	@Success		200	{array}		int	"Fibonacci sequence items"
+//	@Success		200	{array}		string "Fibonacci sequence items"
 //	@Failure		400	{object}	object
 //	@Failure		500	{object}	object
 //	@Router			/api/v1/fibonacci/{count} [get]
@@ -52,7 +53,14 @@ func writeFibo(writer gin.ResponseWriter, wantCount int) error {
 	sentCount := 0
 	for fiboVal := range fibonacci.Fibonacci(wantCount) {
 		// Sequence item
-		if _, err := writer.WriteString(fiboVal.String()); err != nil {
+
+		var buf bytes.Buffer
+
+		buf.WriteRune('"')
+		buf.WriteString(fiboVal.String())
+		buf.WriteRune('"')
+
+		if _, err := writer.WriteString(buf.String()); err != nil {
 			return err
 		}
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -48,7 +48,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "type": "integer"
+                                "type": "string"
                             }
                         }
                     },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -42,7 +42,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "type": "integer"
+                                "type": "string"
                             }
                         }
                     },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -28,7 +28,7 @@ paths:
           description: Fibonacci sequence items
           schema:
             items:
-              type: integer
+              type: string
             type: array
         "400":
           description: Bad Request

--- a/main_test.go
+++ b/main_test.go
@@ -38,7 +38,7 @@ func TestGetFibonacci(t *testing.T) {
 			method:         http.MethodGet,
 			url:            "/api/v1/fibonacci/1",
 			wantStatusCode: http.StatusOK,
-			wantContains:   "[0]",
+			wantContains:   "[\"0\"]",
 			wantHeaders:    http.Header(http.Header{"Content-Type": []string{"application/json"}, "Transfer-Encoding": []string{"chunked"}}),
 		},
 		{
@@ -46,7 +46,7 @@ func TestGetFibonacci(t *testing.T) {
 			method:         http.MethodGet,
 			url:            "/api/v1/fibonacci/2",
 			wantStatusCode: http.StatusOK,
-			wantContains:   "[0,1]",
+			wantContains:   "[\"0\",\"1\"]",
 			wantHeaders:    http.Header(http.Header{"Content-Type": []string{"application/json"}, "Transfer-Encoding": []string{"chunked"}}),
 		},
 		{


### PR DESCRIPTION
Here's the deal:
- The Fibo iterator generates `big.Int` and solves the previous problem of `int64` overflows.
- Upon API response, if individual fibo seq items are formatted as a JSON Number (lack of surrounding `"`), then whoever is consuming the data, will treat and parse the items as a number. The outcome depends on the consumer's parser's implementation, but it's more than likely that the final number representation (post-parsing) will break and corrupt the data.
- The Fibo seq items can be parsed back into an appropriate bigint representation if needed.

Before:
<img width="987" height="1000" alt="image" src="https://github.com/user-attachments/assets/c6041de1-f537-4717-9221-cfdaafe05685" />


After:
<img width="987" height="1000" alt="image" src="https://github.com/user-attachments/assets/203a0fe0-5faa-456a-b454-c6b3c7da2bfa" />
 