### PR TITLE
fix: Metrics middleware addr binding

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -24,11 +24,12 @@ func promUrlRelabel(ctx *gin.Context) string {
 // from each request. Must be called before the monitored routes are registered.
 func SetupPromMiddleware(router *gin.Engine, address string, path string) {
 	prom := ginprometheus.NewWithConfig(ginprometheus.Config{
-		Subsystem: "gin",
+		Subsystem:          "gin",
+		DisableBodyReading: true,
 	})
 	prom.ReqCntURLLabelMappingFn = promUrlRelabel
-	prom.Use(router)
 
 	prom.MetricsPath = path
 	prom.SetListenAddress(address)
+	prom.Use(router)
 }


### PR DESCRIPTION
Currently the metrics middleware binds to `8080`, while it should bind to `9090`. This PR fixes it.